### PR TITLE
Pass path to decode as a reference.

### DIFF
--- a/examples/legion-integration.rs
+++ b/examples/legion-integration.rs
@@ -1,7 +1,7 @@
 use assetmanage_rs::*;
 use legion::prelude::*;
 use serde::Deserialize;
-use std::io::ErrorKind;
+use std::{path::PathBuf, io::ErrorKind};
 
 extern crate pretty_env_logger;
 #[macro_use]
@@ -14,7 +14,7 @@ struct TestStruct {
 }
 
 impl Asset for TestStruct {
-    fn decode(b: &[u8]) -> Result<Self, std::io::Error> {
+    fn decode(_path: &PathBuf, b: &[u8]) -> Result<Self, std::io::Error> {
         ron::de::from_bytes::<TestStruct>(&b)
             .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))
     }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -6,7 +6,7 @@ pub trait Asset
 where
     Self: Sized,
 {
-    fn decode(bytes: &[u8]) -> Result<Self, std::io::Error>;
+    fn decode(path: &PathBuf, bytes: &[u8]) -> Result<Self, std::io::Error>;
 }
 
 /// `AssetHandle` holds the Asset and its Metadata

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -154,8 +154,8 @@ impl<A: Asset> Manager<A> {
             None => {
                 if self.asset_handles.get(key)?.status.eq(&LoadStatus::Loading) {
                     while let Ok((k, b)) = self.load_recv.recv() {
-                        if let Ok(a) = A::decode(&b) {
-                            if let Some(handle) = self.asset_handles.get_mut(k) {
+                        if let Some(handle) = self.asset_handles.get_mut(k) {
+                            if let Ok(a) = A::decode(&handle.path, &b) {
                                 handle.set(a);
                                 if key == k {
                                     return Some(handle.get()?.clone());
@@ -205,8 +205,8 @@ impl<A: Asset> Manager<A> {
             }
         }
         while let Ok((key, b)) = self.load_recv.try_recv() {
-            if let Ok(a) = A::decode(&b) {
-                if let Some(handle) = self.asset_handles.get_mut(key) {
+            if let Some(handle) = self.asset_handles.get_mut(key) {
+                if let Ok(a) = A::decode(&handle.path, &b) {
                     handle.set(a)
                 }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use loader::LoadStatus;
 use serde::Deserialize;
-use std::{io::ErrorKind, time::Duration};
+use std::{io::ErrorKind, time::Duration, path::PathBuf};
 
 /// TestStruct demonstrates implementing Asset
 #[derive(Deserialize)]
@@ -10,7 +10,7 @@ struct TestStruct {
 }
 
 impl Asset for TestStruct {
-    fn decode(b: &[u8]) -> Result<Self, std::io::Error> {
+    fn decode(_path: &PathBuf, b: &[u8]) -> Result<Self, std::io::Error> {
         ron::de::from_bytes::<TestStruct>(&b)
             .map_err(|e| std::io::Error::new(ErrorKind::InvalidData, e))
     }


### PR DESCRIPTION
This is useful for finding a relative path when we have assets that load additional data from the disk.